### PR TITLE
Fix use of ttyAMA0 where there are no other ports

### DIFF
--- a/server.js
+++ b/server.js
@@ -98,7 +98,7 @@ serialport.list(function (err, ports) {
 
 	// if on rPi - http://www.hobbytronics.co.uk/raspberry-pi-serial-port
 	if (fs.existsSync('/dev/ttyAMA0') && config.usettyAMA0 == 1) {
-		ports.push({comName:'/dev/ttyAMA0',manufacturer: undefined,pnpId: 'raspberryPi__GPIO'});
+		(ports = ports || []).push({comName:'/dev/ttyAMA0',manufacturer: undefined,pnpId: 'raspberryPi__GPIO'});
 		console.log('adding /dev/ttyAMA0 because it is enabled in config.js, you may need to enable it in the os - http://www.hobbytronics.co.uk/raspberry-pi-serial-port');
 	}
 


### PR DESCRIPTION
I had a issue when trying to use /dev/ttyAMA0 on a raspberry pi with no other serial devices. Ports array is undefined if there are no other devices causing an error when ttyAMA0 was pushed to the array. Added a check that creates the array if undefined before pushing.